### PR TITLE
Refactor network code

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,3 @@
 # vim: ft=toml
 [toolchain]
-channel = "nightly-2024-04-17"
+channel = "nightly-2024-05-15"

--- a/src/algebra/element.rs
+++ b/src/algebra/element.rs
@@ -109,7 +109,7 @@ overload!((a: &mut Mod11) *= (b: ?Mod11) {
 
 impl ConstantTimeEq for Mod11 {
     fn ct_eq(&self, other: &Self) -> Choice {
-        ((self == other) as u8).into()
+        u8::from(self == other).into()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 #![allow(refining_impl_trait)]
 #![allow(dead_code)]
 #![feature(async_fn_traits)]
+#![allow(clippy::cast_possible_truncation)]
 
 mod algebra;
 pub mod net;

--- a/src/net/agency.rs
+++ b/src/net/agency.rs
@@ -213,7 +213,7 @@ impl<B: Broadcast, D: Digest> VerifiedBroadcast<B, D> {
         // 3. Hash the hashes together and broadcast that
         event!(Level::INFO, "Broadcast sum of all commits");
         let mut digest = D::new();
-        for hash in msg_hashes.iter() {
+        for hash in &msg_hashes {
             digest.update(hash);
         }
         let sum: Box<[u8]> = digest.finalize().to_vec().into_boxed_slice();

--- a/src/net/connection.rs
+++ b/src/net/connection.rs
@@ -160,7 +160,6 @@ impl<R: AsyncRead + Unpin + Send, W: AsyncWrite + Unpin + Send> SplitChannel for
     fn split(&mut self) -> (&mut Self::Sender, &mut Self::Receiver) {
         (&mut self.sender, &mut self.receiver)
     }
-
 }
 
 pub type TcpConnection = Connection<OwnedReadHalf, OwnedWriteHalf>;
@@ -173,7 +172,7 @@ impl TcpConnection {
         Self::new(reader, writer)
     }
 
-    pub fn to_tcp_stream(self) -> TcpStream  {
+    pub fn to_tcp_stream(self) -> TcpStream {
         let (r, w) = self.destroy();
         // UNWRAP: Should never fail, as we build the connection from two
         // streams before. However! One could construct TcpConnection manually
@@ -186,7 +185,6 @@ impl TcpConnection {
         self.to_tcp_stream().shutdown().await
     }
 }
-
 
 /// Connection to a in-memory data stream.
 /// This always have a corresponding other connection in the same process.

--- a/src/net/connection.rs
+++ b/src/net/connection.rs
@@ -78,16 +78,16 @@ impl<R: AsyncRead, W: AsyncWrite> Connection<R, W> {
     }
 }
 
-
 pub struct Sending<W: AsyncWrite>(FramedWrite<W, LengthDelimitedCodec>);
 pub struct Receiving<R: AsyncRead>(FramedRead<R, LengthDelimitedCodec>);
-
 
 impl<W: AsyncWrite + Unpin + Send> SendBytes for Sending<W> {
     type SendError = ConnectionError;
 
     async fn send_bytes(&mut self, bytes: Bytes) -> Result<(), Self::SendError> {
-        SinkExt::<_>::send(&mut self.0, bytes).await.map_err(|_| ConnectionError::Closed)
+        SinkExt::<_>::send(&mut self.0, bytes)
+            .await
+            .map_err(|_| ConnectionError::Closed)
     }
 }
 
@@ -95,7 +95,8 @@ impl<R: AsyncRead + Unpin + Send> RecvBytes for Receiving<R> {
     type RecvError = ConnectionError;
 
     async fn recv_bytes(&mut self) -> Result<BytesMut, Self::RecvError> {
-        self.0.next()
+        self.0
+            .next()
             .await
             .ok_or(ConnectionError::Closed)?
             .map_err(|e| ConnectionError::Unknown(Box::new(e)))
@@ -117,7 +118,6 @@ impl<R: AsyncRead + Unpin + Send, W: AsyncWrite + Unpin + Send> Connection<R, W>
     pub async fn recv<T: serde::de::DeserializeOwned>(&mut self) -> Result<T, ConnectionError> {
         self.receiver.recv().await
     }
-
 }
 
 impl<
@@ -148,7 +148,7 @@ impl<
     }
 }
 
-impl<R: AsyncRead + Unpin + Send, W: AsyncWrite + Unpin + Send> Channel for Connection<R,W> {
+impl<R: AsyncRead + Unpin + Send, W: AsyncWrite + Unpin + Send> Channel for Connection<R, W> {
     type Error = ConnectionError;
 }
 

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -8,7 +8,6 @@ pub mod connection;
 pub mod mux;
 pub mod network;
 
-
 pub trait SendBytes: Send {
     type SendError: Error + Send + Sync + 'static;
 
@@ -39,7 +38,6 @@ impl<S: SendBytes> SendBytes for &mut S {
     }
 }
 
-
 pub trait RecvBytes: Send {
     type RecvError: Error + Send + Sync + 'static;
     fn recv_bytes(
@@ -64,7 +62,6 @@ impl<R: RecvBytes> RecvBytes for &mut R {
     ) -> impl std::future::Future<Output = Result<BytesMut, Self::RecvError>> + Send {
         (**self).recv_bytes()
     }
-
 }
 
 /// A communication medium between you and another party.
@@ -77,17 +74,14 @@ impl<C: Channel> Channel for &mut C {
     type Error = C::Error;
 }
 
-
-
 /// A [Channel] which can be split into a sender and receiver.
 pub trait SplitChannel: Channel + Send {
     type Sender: SendBytes<SendError = Self::SendError> + Send;
     type Receiver: RecvBytes<RecvError = Self::RecvError> + Send;
     fn split(&mut self) -> (&mut Self::Sender, &mut Self::Receiver);
-
 }
 
-impl<'a, C: SplitChannel> SplitChannel for &'a mut C  {
+impl<'a, C: SplitChannel> SplitChannel for &'a mut C {
     type Sender = C::Sender;
     type Receiver = C::Receiver;
 
@@ -95,7 +89,6 @@ impl<'a, C: SplitChannel> SplitChannel for &'a mut C  {
         (**self).split()
     }
 }
-
 
 /// Tune to a specific channel
 pub trait Tuneable {

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -67,8 +67,8 @@ impl<R: RecvBytes> RecvBytes for &mut R {
 /// A communication medium between you and another party.
 ///
 /// Allows you to send and receive arbitrary messages.
-pub trait Channel: SendBytes + RecvBytes {
-    type Error: Error + Send;
+pub trait Channel: SendBytes<SendError = Self::Error> + RecvBytes<RecvError = Self::Error> {
+    type Error: Error + Send + Sync + 'static;
 }
 impl<C: Channel> Channel for &mut C {
     type Error = C::Error;

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -72,24 +72,24 @@ impl<'a, C: Channel> Channel for &'a mut C {
 
 /// Tune to a specific channel
 pub trait Tuneable {
-    type Error: Error + Send + 'static;
+    type TuningError: Error + Send + 'static;
 
     fn id(&self) -> usize;
 
     fn recv_from<T: serde::de::DeserializeOwned>(
         &mut self,
         idx: usize,
-    ) -> impl Future<Output = Result<T, Self::Error>>;
+    ) -> impl Future<Output = Result<T, Self::TuningError>>;
 
     fn send_to<T: serde::Serialize + Sync>(
         &mut self,
         idx: usize,
         msg: &T,
-    ) -> impl std::future::Future<Output = Result<(), Self::Error>>;
+    ) -> impl std::future::Future<Output = Result<(), Self::TuningError>>;
 }
 
 impl<'a, R: Tuneable + ?Sized> Tuneable for &'a mut R {
-    type Error = R::Error;
+    type TuningError = R::TuningError;
 
     fn id(&self) -> usize {
         (**self).id()
@@ -98,7 +98,7 @@ impl<'a, R: Tuneable + ?Sized> Tuneable for &'a mut R {
     fn recv_from<T: serde::de::DeserializeOwned>(
         &mut self,
         idx: usize,
-    ) -> impl Future<Output = Result<T, Self::Error>> {
+    ) -> impl Future<Output = Result<T, Self::TuningError>> {
         (**self).recv_from(idx)
     }
 
@@ -106,7 +106,7 @@ impl<'a, R: Tuneable + ?Sized> Tuneable for &'a mut R {
         &mut self,
         idx: usize,
         msg: &T,
-    ) -> impl std::future::Future<Output = Result<(), Self::Error>> {
+    ) -> impl std::future::Future<Output = Result<(), Self::TuningError>> {
         (**self).send_to(idx, msg)
     }
 }

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -1,74 +1,101 @@
-use std::error::Error;
+use std::{error::Error, future::Future};
 
-use futures::Future;
-
-use crate::net::connection::{Connection, ConnectionError, RecvBytes, SendBytes};
+use serde::{de::DeserializeOwned, Serialize};
+use tokio_util::bytes::{Bytes, BytesMut};
 
 pub mod agency;
 pub mod connection;
 pub mod mux;
 pub mod network;
 
+
+pub trait SendBytes: Send {
+    type SendError: Error + Send + Sync + 'static;
+
+    fn send_bytes(
+        &mut self,
+        bytes: Bytes,
+    ) -> impl std::future::Future<Output = Result<(), Self::SendError>> + Send;
+
+    fn send<T: Serialize + Sync>(
+        &mut self,
+        msg: &T,
+    ) -> impl Future<Output = Result<(), Self::SendError>> + Send {
+        async {
+            let msg = bincode::serialize(msg).unwrap();
+            self.send_bytes(msg.into()).await
+        }
+    }
+}
+
+impl<S: SendBytes> SendBytes for &mut S {
+    type SendError = S::SendError;
+
+    fn send_bytes(
+        &mut self,
+        bytes: Bytes,
+    ) -> impl std::future::Future<Output = Result<(), Self::SendError>> + Send {
+        (**self).send_bytes(bytes)
+    }
+}
+
+
+pub trait RecvBytes: Send {
+    type RecvError: Error + Send + Sync + 'static;
+    fn recv_bytes(
+        &mut self,
+    ) -> impl std::future::Future<Output = Result<BytesMut, Self::RecvError>> + Send;
+
+    fn recv<T: DeserializeOwned>(
+        &mut self,
+    ) -> impl Future<Output = Result<T, Self::RecvError>> + Send {
+        async {
+            let msg = self.recv_bytes().await?;
+            Ok(bincode::deserialize(&msg).unwrap())
+        }
+    }
+}
+
+impl<R: RecvBytes> RecvBytes for &mut R {
+    type RecvError = R::RecvError;
+
+    fn recv_bytes(
+        &mut self,
+    ) -> impl std::future::Future<Output = Result<BytesMut, Self::RecvError>> + Send {
+        (**self).recv_bytes()
+    }
+
+}
+
 /// A communication medium between you and another party.
 ///
 /// Allows you to send and receive arbitrary messages.
-pub trait Channel {
-    type Error: Error + Send + Sync + 'static;
-
-    /// Send a message over the channel
-    ///
-    /// * `msg`: message to serialize and send
-    fn send<T: serde::Serialize + Sync>(
-        &mut self,
-        msg: &T,
-    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
-
-    fn recv<T: serde::de::DeserializeOwned>(
-        &mut self,
-    ) -> impl Future<Output = Result<T, Self::Error>> + Send;
+pub trait Channel: SendBytes + RecvBytes {
+    type Error: Error + Send;
+}
+impl<C: Channel> Channel for &mut C {
+    type Error = C::Error;
 }
 
-impl<
-        R: tokio::io::AsyncRead + std::marker::Unpin + Send,
-        W: tokio::io::AsyncWrite + std::marker::Unpin + Send,
-    > Channel for Connection<R, W>
-{
-    type Error = ConnectionError;
 
-    async fn send<T: serde::Serialize + Sync>(&mut self, msg: &T) -> Result<(), Self::Error> {
-        Connection::send(self, &msg).await
-    }
-
-    fn recv<T: serde::de::DeserializeOwned>(
-        &mut self,
-    ) -> impl Future<Output = Result<T, Self::Error>> {
-        Connection::recv(self)
-    }
-}
 
 /// A [Channel] which can be split into a sender and receiver.
-pub trait SplitChannel: Channel {
-    type Sender: SendBytes<SendError = Self::Error> + Send;
-    type Receiver: RecvBytes<RecvError = Self::Error> + Send;
+pub trait SplitChannel: Channel + Send {
+    type Sender: SendBytes<SendError = Self::SendError> + Send;
+    type Receiver: RecvBytes<RecvError = Self::RecvError> + Send;
     fn split(&mut self) -> (&mut Self::Sender, &mut Self::Receiver);
+
 }
 
-impl<'a, C: Channel> Channel for &'a mut C {
-    type Error = C::Error;
+impl<'a, C: SplitChannel> SplitChannel for &'a mut C  {
+    type Sender = C::Sender;
+    type Receiver = C::Receiver;
 
-    fn send<T: serde::Serialize + Sync>(
-        &mut self,
-        msg: &T,
-    ) -> impl Future<Output = Result<(), Self::Error>> + Send {
-        (**self).send(msg)
-    }
-
-    fn recv<T: serde::de::DeserializeOwned>(
-        &mut self,
-    ) -> impl Future<Output = Result<T, Self::Error>> + Send {
-        (**self).recv()
+    fn split(&mut self) -> (&mut Self::Sender, &mut Self::Receiver) {
+        (**self).split()
     }
 }
+
 
 /// Tune to a specific channel
 pub trait Tuneable {
@@ -85,7 +112,7 @@ pub trait Tuneable {
         &mut self,
         idx: usize,
         msg: &T,
-    ) -> impl std::future::Future<Output = Result<(), Self::TuningError>>;
+    ) -> impl Future<Output = Result<(), Self::TuningError>>;
 }
 
 impl<'a, R: Tuneable + ?Sized> Tuneable for &'a mut R {
@@ -106,7 +133,7 @@ impl<'a, R: Tuneable + ?Sized> Tuneable for &'a mut R {
         &mut self,
         idx: usize,
         msg: &T,
-    ) -> impl std::future::Future<Output = Result<(), Self::TuningError>> {
+    ) -> impl Future<Output = Result<(), Self::TuningError>> {
         (**self).send_to(idx, msg)
     }
 }

--- a/src/net/mux.rs
+++ b/src/net/mux.rs
@@ -19,9 +19,7 @@ use tokio::join;
 
 use crate::{
     help,
-    net::{
-        network::Network, Channel, RecvBytes, SendBytes, SplitChannel
-    },
+    net::{network::Network, Channel, RecvBytes, SendBytes, SplitChannel},
 };
 
 #[derive(Debug, Error)]

--- a/src/net/network.rs
+++ b/src/net/network.rs
@@ -151,7 +151,7 @@ impl<C: SplitChannel> Network<C> {
     {
         let my_id = self.index;
         let (mut tx, mut rx): (Vec<_>, Vec<_>) =
-            self.connections.iter_mut().map(|c| c.split()).unzip();
+            self.connections.iter_mut().map(super::SplitChannel::split).unzip();
 
         let packet: Bytes = bincode::serialize(&msg).unwrap().into();
         let outgoing = tx.iter_mut().enumerate().map(|(id, conn)| {
@@ -199,6 +199,11 @@ impl<C: SplitChannel> Network<C> {
     /// will be send to party `i`.
     ///
     /// * `msg`: message to send and receive
+    ///
+    /// # Errors
+    ///
+    ///  Returns a [``NetworkError``] with an ``id`` if the underlying connection to that ``id`` fails.
+    ///
     pub async fn symmetric_unicast<T>(&mut self, mut msgs: Vec<T>) -> NetResult<Vec<T>, C>
     where
         T: serde::Serialize + serde::de::DeserializeOwned + Sync,
@@ -207,7 +212,7 @@ impl<C: SplitChannel> Network<C> {
         let my_own_msg = msgs.remove(my_id);
 
         let (mut tx, mut rx): (Vec<_>, Vec<_>) =
-            self.connections.iter_mut().map(|c| c.split()).unzip();
+            self.connections.iter_mut().map(super::SplitChannel::split).unzip();
 
         let outgoing = tx
             .iter_mut()

--- a/src/net/network.rs
+++ b/src/net/network.rs
@@ -298,7 +298,7 @@ impl<C: SplitChannel> Network<C> {
     }
 
 
-    pub(crate) fn as_mut<'a>(&'a mut self) -> Network<&'a mut C> {
+    pub(crate) fn as_mut(&mut self) -> Network<&mut C> {
         let connections = self.connections.iter_mut().collect();
         Network { connections, index: self.index }
     }

--- a/src/net/network.rs
+++ b/src/net/network.rs
@@ -150,8 +150,11 @@ impl<C: SplitChannel> Network<C> {
         T: serde::Serialize + serde::de::DeserializeOwned + Sync,
     {
         let my_id = self.index;
-        let (mut tx, mut rx): (Vec<_>, Vec<_>) =
-            self.connections.iter_mut().map(super::SplitChannel::split).unzip();
+        let (mut tx, mut rx): (Vec<_>, Vec<_>) = self
+            .connections
+            .iter_mut()
+            .map(super::SplitChannel::split)
+            .unzip();
 
         let packet: Bytes = bincode::serialize(&msg).unwrap().into();
         let outgoing = tx.iter_mut().enumerate().map(|(id, conn)| {
@@ -211,8 +214,11 @@ impl<C: SplitChannel> Network<C> {
         let my_id = self.index;
         let my_own_msg = msgs.remove(my_id);
 
-        let (mut tx, mut rx): (Vec<_>, Vec<_>) =
-            self.connections.iter_mut().map(super::SplitChannel::split).unzip();
+        let (mut tx, mut rx): (Vec<_>, Vec<_>) = self
+            .connections
+            .iter_mut()
+            .map(super::SplitChannel::split)
+            .unzip();
 
         let outgoing = tx
             .iter_mut()
@@ -302,10 +308,12 @@ impl<C: SplitChannel> Network<C> {
         todo!("Initiate a drop vote");
     }
 
-
     pub(crate) fn as_mut(&mut self) -> Network<&mut C> {
         let connections = self.connections.iter_mut().collect();
-        Network { connections, index: self.index }
+        Network {
+            connections,
+            index: self.index,
+        }
     }
 }
 
@@ -483,9 +491,7 @@ impl InMemoryNetwork {
         let futs = self
             .connections
             .into_iter()
-            .map(|conn| async move {
-                conn.shutdown().await
-            });
+            .map(|conn| async move { conn.shutdown().await });
         join_all(futs).await.into_iter().map_ok(|_| {}).collect()
     }
 }
@@ -534,7 +540,10 @@ impl TcpNetwork {
             stream.set_nodelay(true).unwrap();
         }
 
-        let connections = parties.into_iter().map(Connection::from_tcp_stream).collect();
+        let connections = parties
+            .into_iter()
+            .map(Connection::from_tcp_stream)
+            .collect();
 
         let mut network = Self {
             connections,
@@ -549,9 +558,7 @@ impl TcpNetwork {
         let futs = self
             .connections
             .into_iter()
-            .map(|conn| async move {
-                conn.shutdown().await
-            });
+            .map(|conn| async move { conn.shutdown().await });
         join_all(futs).await.into_iter().map_ok(|_| {}).collect()
     }
 }

--- a/src/ot/mod.rs
+++ b/src/ot/mod.rs
@@ -64,7 +64,7 @@ impl<C: Channel> ObliviousTransfer<C> for MockOT {
 struct MockOTSender();
 
 impl<C: Channel> ObliviousSend<C> for MockOTSender {
-    type Error = C::Error;
+    type Error = C::SendError;
 
     async fn send<T: serde::Serialize + Sync>(
         pkg0: &T,
@@ -79,7 +79,7 @@ impl<C: Channel> ObliviousSend<C> for MockOTSender {
 struct MockOTReceiver();
 
 impl<C: Channel> ObliviousReceive<C> for MockOTReceiver {
-    type Error = C::Error;
+    type Error = C::RecvError;
 
     async fn choose<T: serde::de::DeserializeOwned>(
         choice: bool,

--- a/src/protocols/cutnchoose.rs
+++ b/src/protocols/cutnchoose.rs
@@ -90,7 +90,9 @@ mod test {
     use crate::{
         algebra::element::Element32,
         net::{
-            agency::Broadcast, connection::{self, ConnectionError, DuplexConnection}, Channel, RecvBytes, SendBytes, SplitChannel
+            agency::Broadcast,
+            connection::{self, ConnectionError, DuplexConnection},
+            Channel, RecvBytes, SendBytes, SplitChannel,
         },
         protocols::cutnchoose::{choose, cut},
         schemes::{
@@ -157,7 +159,8 @@ mod test {
 
         fn recv_bytes(
             &mut self,
-        ) -> impl std::future::Future<Output = Result<tokio_util::bytes::BytesMut, Self::RecvError>> + Send {
+        ) -> impl std::future::Future<Output = Result<tokio_util::bytes::BytesMut, Self::RecvError>> + Send
+        {
             self.inner.recv_bytes()
         }
     }

--- a/src/protocols/cutnchoose.rs
+++ b/src/protocols/cutnchoose.rs
@@ -107,16 +107,16 @@ mod test {
     }
 
     impl Broadcast for SingleBroadcast {
-        type Error = <DuplexConnection as Channel>::Error;
+        type BroadcastError = <DuplexConnection as Channel>::Error;
 
         fn broadcast(
             &mut self,
             msg: &(impl serde::Serialize + Sync),
-        ) -> impl std::future::Future<Output = Result<(), Self::Error>> {
+        ) -> impl std::future::Future<Output = Result<(), Self::BroadcastError>> {
             self.inner.send(msg)
         }
 
-        async fn symmetric_broadcast<T>(&mut self, msg: T) -> Result<Vec<T>, Self::Error>
+        async fn symmetric_broadcast<T>(&mut self, msg: T) -> Result<Vec<T>, Self::BroadcastError>
         where
             T: serde::Serialize + serde::de::DeserializeOwned + Sync,
         {
@@ -134,7 +134,7 @@ mod test {
         fn recv_from<T: serde::de::DeserializeOwned>(
             &mut self,
             _idx: usize,
-        ) -> impl futures::prelude::Future<Output = Result<T, Self::Error>> {
+        ) -> impl futures::prelude::Future<Output = Result<T, Self::BroadcastError>> {
             self.inner.recv()
         }
 

--- a/src/protocols/mod.rs
+++ b/src/protocols/mod.rs
@@ -2,3 +2,4 @@ pub mod beaver;
 pub mod cointoss;
 mod cutnchoose;
 mod rand;
+pub mod voting;

--- a/src/protocols/voting.rs
+++ b/src/protocols/voting.rs
@@ -1,0 +1,63 @@
+use std::env::Args;
+
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+
+use crate::net::Communicate;
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct Proposal<T> {
+    initative: T,
+    creator: usize,
+}
+
+
+pub trait Initiative: Serialize + DeserializeOwned + Sync {
+    type Args;
+    fn name() -> &'static str;
+    fn execute(args: Args);
+}
+
+impl<T: Initiative> Proposal<T> {
+
+    pub async fn initiate<C: Communicate>(initative: T, mut coms: C) -> Result<Option<Self>, C::BroadcastError> {
+        let creator = coms.id();
+        let proposal = Self {initative, creator};
+        let request = ProposalRequest(proposal);
+
+        coms.broadcast(&request).await?;
+        request.accept(coms).await
+    }
+
+    pub fn execute(self, args: Args) {
+        T::execute(args)
+    }
+
+}
+
+#[repr(transparent)]
+#[derive(Clone, Serialize, Deserialize)]
+pub struct ProposalRequest<T>(Proposal<T>);
+
+impl<T: Initiative> ProposalRequest<T> {
+
+    async fn vote<C: Communicate>(self, vote: bool, mut coms: C) -> Result<Option<Proposal<T>>, C::BroadcastError> {
+        let votes = coms.symmetric_broadcast(vote).await?;
+        let n =  votes.len();
+        let yes_votes = votes.into_iter().filter(|&v| v).count();
+        let res = if yes_votes > n {
+            Some(self.0)
+        } else {
+            None
+        };
+        Ok(res)
+    }
+
+    pub async fn accept<C: Communicate>(self, coms: C) -> Result<Option<Proposal<T>>, C::BroadcastError> {
+        self.vote(true, coms).await
+    }
+
+    pub async fn reject<C: Communicate>(self, coms: C) -> Result<Option<Proposal<T>>, C::BroadcastError>{
+        self.vote(false, coms).await
+
+    }
+}

--- a/src/protocols/voting.rs
+++ b/src/protocols/voting.rs
@@ -10,7 +10,6 @@ pub struct Proposal<T> {
     creator: usize,
 }
 
-
 pub trait Initiative: Serialize + DeserializeOwned + Sync {
     type Args;
     fn name() -> &'static str;
@@ -18,10 +17,12 @@ pub trait Initiative: Serialize + DeserializeOwned + Sync {
 }
 
 impl<T: Initiative> Proposal<T> {
-
-    pub async fn initiate<C: Communicate>(initative: T, mut coms: C) -> Result<Option<Self>, C::BroadcastError> {
+    pub async fn initiate<C: Communicate>(
+        initative: T,
+        mut coms: C,
+    ) -> Result<Option<Self>, C::BroadcastError> {
         let creator = coms.id();
-        let proposal = Self {initative, creator};
+        let proposal = Self { initative, creator };
         let request = ProposalRequest(proposal);
 
         coms.broadcast(&request).await?;
@@ -31,7 +32,6 @@ impl<T: Initiative> Proposal<T> {
     pub fn execute(self, args: Args) {
         T::execute(args)
     }
-
 }
 
 #[repr(transparent)]
@@ -39,25 +39,29 @@ impl<T: Initiative> Proposal<T> {
 pub struct ProposalRequest<T>(Proposal<T>);
 
 impl<T: Initiative> ProposalRequest<T> {
-
-    async fn vote<C: Communicate>(self, vote: bool, mut coms: C) -> Result<Option<Proposal<T>>, C::BroadcastError> {
+    async fn vote<C: Communicate>(
+        self,
+        vote: bool,
+        mut coms: C,
+    ) -> Result<Option<Proposal<T>>, C::BroadcastError> {
         let votes = coms.symmetric_broadcast(vote).await?;
-        let n =  votes.len();
+        let n = votes.len();
         let yes_votes = votes.into_iter().filter(|&v| v).count();
-        let res = if yes_votes > n {
-            Some(self.0)
-        } else {
-            None
-        };
+        let res = if yes_votes > n { Some(self.0) } else { None };
         Ok(res)
     }
 
-    pub async fn accept<C: Communicate>(self, coms: C) -> Result<Option<Proposal<T>>, C::BroadcastError> {
+    pub async fn accept<C: Communicate>(
+        self,
+        coms: C,
+    ) -> Result<Option<Proposal<T>>, C::BroadcastError> {
         self.vote(true, coms).await
     }
 
-    pub async fn reject<C: Communicate>(self, coms: C) -> Result<Option<Proposal<T>>, C::BroadcastError>{
+    pub async fn reject<C: Communicate>(
+        self,
+        coms: C,
+    ) -> Result<Option<Proposal<T>>, C::BroadcastError> {
         self.vote(false, coms).await
-
     }
 }

--- a/src/schemes/shamir.rs
+++ b/src/schemes/shamir.rs
@@ -289,7 +289,7 @@ pub async fn deflate<F: Field + serde::Serialize + serde::de::DeserializeOwned, 
     z: InflatedShare<F>,
     net: &mut U,
     rng: &mut impl RngCore,
-) -> Result<Share<F>, <U as Unicast>::Error> {
+) -> Result<Share<F>, <U as Unicast>::UnicastError> {
     let z = z.0;
     // let x = z.x;
     let n = ctx.ids.len();


### PR DESCRIPTION
Reduce the amount of overlap between different send/recv methods.
Now everything just references the simple Recv/SendBytes.